### PR TITLE
Make hessio installable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,4 +39,4 @@ add_definitions(-D${BuildConfig})
 
 # build the libraries and executables
 add_subdirectory("src")
-                   
+install(DIRECTORY include/ DESTINATION include/hessio)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 set( HESSIO_SOURCES
                     atmprof.c
                     current.c
@@ -38,6 +41,7 @@ add_library( hessio++ SHARED
              EventIO.cc 
              ${PROJECT_SOURCE_DIR}/include/EventIO.hh
              ${HESSIO_SOURCES} ${HESSIO_INCLUDES} )
+
 
 
 # C Executables
@@ -87,3 +91,7 @@ target_link_libraries( statio hessio++ )
 add_executable( filterio filterio.cc )
 target_link_libraries( filterio hessio++ )
 
+install (TARGETS hessio hessio++ testio read_hess read_hess_nr split_hessio check_trgmask gen_trgmask extract_hess merge_simtel list_histograms add_histograms fcat  testio++ statio filterio
+	RUNTIME DESTINATION bin
+	LIBRARY DESTINATION lib
+)


### PR DESCRIPTION
You can now use
```
cmake /path/to/CMakelists.txt -DCMAKE_INSTALL_PREFIX=/install/dir
make
make install
```

This will install the librarys in `/install/dir/lib`,
the executables in `/install/dir/bin` and
the header files in `/install/dir/include/hessio`

Any Application using the lbrarys can easily be linked
against these paths without the need of setting the
LD_LIBRARY_PATH.